### PR TITLE
move pynq import to detect_devices function

### DIFF
--- a/pynqutils/runtime/detect_devices.py
+++ b/pynqutils/runtime/detect_devices.py
@@ -1,11 +1,9 @@
 # Copyright (C) 2022 Xilinx, Inc
 # SPDX-License-Identifier: BSD-3-Clause
 
-import pynq
-
-
 def detect_devices(active_only=False):
     """Return a list containing all the detected devices names."""
+    import pynq
     devices = pynq.Device.devices
     if not devices:
         raise RuntimeError("No device found in the system")


### PR DESCRIPTION
Right now trying to import pynqutils on a system without pynq installed results in an import error due to the import from https://github.com/Xilinx/PYNQ-Utils/blob/main/pynqutils/runtime/__init__.py#L4

This change would allow us to import pynqutils on x86 or other systems without needing to install pynq. 