### PR TITLE
removed unused pkg_resources import

### DIFF
--- a/pynqutils/build_utils/xsa_parser.py
+++ b/pynqutils/build_utils/xsa_parser.py
@@ -16,7 +16,6 @@ from typing import Dict, Union
 from xml.dom.minidom import Element
 from xml.etree import ElementTree
 
-import pkg_resources
 
 
 class XsaParsingCannotFindBlockDesignName(Exception):


### PR DESCRIPTION
In newer versions of Python importing `pkg_resources` gives a deprecation warning:

``` python
UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
```

The offending line is here:
https://github.com/Xilinx/PYNQ-Utils/blob/a43d9b1fa92910d72079977cb58cde62bd7fbbd6/pynqutils/build_utils/xsa_parser.py#L19

which is unused, so can be safely removed.